### PR TITLE
Remove /api/v1 from request URLS

### DIFF
--- a/src/components/Discussion/DiscussionPage.jsx
+++ b/src/components/Discussion/DiscussionPage.jsx
@@ -67,8 +67,8 @@ export default function DiscussionPage({
 		setError("");
 		try {
 			const endpoint = isJoined
-				? `/api/v1/discussions/${id}/unjoin`
-				: `/api/v1/discussions/${id}/join`;
+				? `/discussions/${id}/unjoin`
+				: `/discussions/${id}/join`;
 
 			const response = await fetch(
 				`${import.meta.env.VITE_API_BASE_URL}${endpoint}`,
@@ -92,7 +92,7 @@ export default function DiscussionPage({
 		setError("");
 		try {
 			const response = await fetch(
-				`${import.meta.env.VITE_API_BASE_URL}/api/v1/discussions/${id}`,
+				`${import.meta.env.VITE_API_BASE_URL}/discussions/${id}`,
 				{
 					method: "DELETE",
 				},

--- a/src/components/UserLogin/Login.jsx
+++ b/src/components/UserLogin/Login.jsx
@@ -17,7 +17,7 @@ const Login = () => {
 
 		try {
 			const response = await fetch(
-				`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/login`,
+				`${import.meta.env.VITE_API_BASE_URL}/auth/login`,
 				{
 					method: "POST",
 					headers: {


### PR DESCRIPTION
Some of our requests were to `process.env.VITE_API_BASE_URL/api/v1/some/endpoint` while others were to `process.env.VITE_API_BASE_URL/some/endpoint`.

The /api should be part of the base URL, we don't ever need to use the domain name for the backend WITHOUT the API. Similarly, we only have a v1 application for now and I don't anticipate anyone working on a v2, so we can include that in the environment variable too.

I've updated all requests to use go to `VITE_API_BASE_URL/some/endpoint` instead.